### PR TITLE
Fixes #88

### DIFF
--- a/supportfiles/portals/captiveportal/default/create.inc.php
+++ b/supportfiles/portals/captiveportal/default/create.inc.php
@@ -47,7 +47,7 @@
 			}
 		}else{
 			$randomPassword = $endpointGroupAuthorization['ciscoAVPairPSK'];
-			$randomPSK = "psk=".$userPsk;
+			$randomPSK = "psk=".$randomPassword;
 		}
 		
 		if($endpointGroupAuthorization['termLengthSeconds'] == 0){


### PR DESCRIPTION
This changes resolves the issue I opened (#88) in the captive portal self onboarding workflow.

It introduces two new variables - `devicePsk` and `devicePassword` to account for the various ways a device's passphrase can be set (ie, random vs static).